### PR TITLE
Fix find_packages to exclude tests.

### DIFF
--- a/celery_statsd/__about__.py
+++ b/celery_statsd/__about__.py
@@ -9,7 +9,7 @@ __summary__ = (
 )
 __uri__ = "https://github.com/lyst/celery-statsd/"
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __author__ = "Lyst LTD"
 __email__ = "info@lyst.com"

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     author=about['__author__'],
     author_email=about['__email__'],
 
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     zip_safe=False,
 )


### PR DESCRIPTION
This will allow proper bdist builds. Currently bdist creates two modules one
of which is generically called 'tests' and shouldn't exist.